### PR TITLE
Adding customization for the `this` object in random, get, set, clear functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ default uses browser cookies.
 A function that clears/unsets an `experiment`. By
 default uses browser cookies.
 
+##### thisContext
+
+When set, the `this` object in `random`, `get`, `set`, `clear` will be
+the supplied value. This could be useful when the Experiment logic depends
+on props from the parent component.
+
 #### Context
 
 `get, set, clear, random` can also be set from `context`. If these props

--- a/react-ab.js
+++ b/react-ab.js
@@ -89,6 +89,7 @@
       , get: React.PropTypes.func
       , set: React.PropTypes.func
       , clear: React.PropTypes.func
+      , thisContext: React.PropTypes.object
     }
 
     , contextTypes: {
@@ -104,7 +105,7 @@
     /* Private */
     , _random: function () {
       var fn = this.props.random || this.context.randomExperiment || random;
-      return fn();
+      return fn.call(this.props.thisContext);
     }
 
     , _defaultFunc: function (name, fn) {
@@ -116,15 +117,15 @@
     }
 
     , _get: function () {
-      return this._defaultFunc("get")(this._keyName());
+      return this._defaultFunc("get").call(this.props.thisContext, this._keyName());
     }
 
     , _set: function (v) {
-      return this._defaultFunc("set")(this._keyName(), v);
+      return this._defaultFunc("set").call(this.props.thisContext, this._keyName(), v);
     }
 
     , _clear: function () {
-      return this._defaultFunc("clear")(this._keyName());
+      return this._defaultFunc("clear").call(this.props.thisContext, this._keyName());
     }
 
     /* Lifecycle */


### PR DESCRIPTION
Hello, we tried this repo a few days ago and found this is quite useful to my current React app.
There is, however, a small problem when I need more complex logic in the Experiment.

### Problem

The situation is, our AB tests aren't completely determined in the client side. We need to send a request to our server to determine which group should we supply for the user.
(e.g. we want to perform experiment on pre-release features on vip users only.)

To make things easy to maintain, we have defined a wrapper container, like this:

```js
import { Experiment } from 'react-ab';

class CustomExperiment extends React.Component {
    componentDidMount() {
        // send request and save the result in this.props.test_data
    }

    customGet(name) {
        // custom logic based on the test_data
        let test_data = this.props.test_data; // Error! 'this' is undefined!
    }

    render () {
        return (
            <Experiment get={ this.customGet } name={ this.props.name }>
                { this.props.children }
            </Experiment>
        );
    }
}
```

As `customGet` is called without proper context, we cannot access the wrapper props.
It would be hard to maintain if we put the data into global storage (e.g. localstorage) and retrieve them later.

### Workaround

There's an ugly workaround, which introduces complexity:
```js
<Experiment get={ (experiment) => this.customGet.call(this, experiment) } name={ this.props.name }>
```

### Solution

We propose a simple solution, to add an extra props `thisContext` in the `<Experiment>` container.
By setting the `thisContext`, we could achieve a much simpler codes:

```js
<Experiment thisContext={ this } get={ this.customGet } name={ this.props.name }>
```

The codes are supplied in this PR. Any feedbacks are welcome.
